### PR TITLE
Added support to constants, capital letters enclosed in % signs.

### DIFF
--- a/Inline.php
+++ b/Inline.php
@@ -373,6 +373,13 @@ class Inline
                 return floatval(str_replace(',', '', $scalar));
             case preg_match(self::getTimestampRegex(), $scalar):
                 return strtotime($scalar);
+            case preg_match_all('/%([A-Z_]+)%/', $scalar, $matches):
+                foreach ($matches[1] as $key => $value) {
+                     if (defined($value)) {
+                         $scalar = str_replace($matches[0][$key], constant($value), $scalar);
+                     }
+                }
+                return $scalar;
             default:
                 return (string) $scalar;
         }


### PR DESCRIPTION
I found mention of this here: http://www.symfony-project.org/book/1_2/05-Configuring-Symfony, but It wasn't implemented old sfYaml nor this new one. Zend Framworks implementation loops all constants, this is nicer, and easier when its enclosed by % signs.
