### PR TITLE
 Fix bug : dump float value in a context where locale sets comma as separator instead of dot 

### DIFF
--- a/Inline.php
+++ b/Inline.php
@@ -348,8 +348,8 @@ class Inline
                 return intval(self::parseScalar(substr($scalar, 2)));
             case 0 === strpos($scalar, '!!php/object:'):
                 return unserialize(substr($scalar, 13));
-            case 0 === strpos($scalar, '!!float'):
-                return floatval(substr($scalar, 7));
+            case 0 === strpos($scalar, '!!float '):
+                return floatval(substr($scalar, 8));
             case ctype_digit($scalar):
                 $raw = $scalar;
                 $cast = intval($scalar);


### PR DESCRIPTION
For example, if LC_ALL is set to fr_FR then float number got ',' as separator ; example : 4,75

In order to follow Yaml Specifications (http://yaml.org/type/float.html) we must replace the comma with a dot, and specify the float type.

Code to reproduce the bug :

``` php

<?php
setlocale(LC_ALL, 'fr_FR.UTF-8', 'fr_FR.UTF8', 'fr_FR.utf-8', 'fr_FR.utf8');
require_once dirname(__FILE__) . '/symfony/src/Symfony/Component/Yaml/Escaper.php';
require_once dirname(__FILE__) . '/symfony/src/Symfony/Component/Yaml/Unescaper.php';
require_once dirname(__FILE__) . '/symfony/src/Symfony/Component/Yaml/Inline.php';
require_once dirname(__FILE__) . '/symfony/src/Symfony/Component/Yaml/Dumper.php';
require_once dirname(__FILE__) . '/symfony/src/Symfony/Component/Yaml/Parser.php';

$tab = array('value' => round(54 / 72, 4));

var_dump($tab);

$dumper = new Symfony\Component\Yaml\Dumper();
$dump = $dumper->dump($tab, 1);

var_dump($dump);

$parser = new Symfony\Component\Yaml\Parser();
$parsed = $parser->parse($dump);

var_dump($parsed);

assert($parsed === $tab);

```
