### PR TITLE
phpDoc documents wrong exception

### DIFF
--- a/Yaml.php
+++ b/Yaml.php
@@ -45,7 +45,7 @@ class Yaml
      *
      * @return array The YAML converted to a PHP array
      *
-     * @throws \InvalidArgumentException If the YAML is not valid
+     * @throws ParseException If the YAML is not valid
      *
      * @api
      */


### PR DESCRIPTION
The documentation of Yaml::parse() is wrong. It doesn't throw an `InvalidArgumentException` but a `ParseException`.
