### PR TITLE
fixed document start bug

### DIFF
--- a/Parser.php
+++ b/Parser.php
@@ -560,14 +560,14 @@ class Parser
         }
 
         // remove start of the document marker (---)
-        $trimmedValue = preg_replace('#^\-\-\-.*?\n#s', '', $value, -1, $count);
+        $trimmedValue = preg_replace('#^\-\-\-$#ms', '', $value, -1, $count);
         if ($count == 1) {
             // items have been removed, update the offset
             $this->offset += substr_count($value, "\n") - substr_count($trimmedValue, "\n");
             $value = $trimmedValue;
 
             // remove end of the document marker (...)
-            $value = preg_replace('#\.\.\.\s*$#s', '', $value);
+            $value = preg_replace('#^\.\.\.$#ms', '', $value);
         }
 
         return $value;


### PR DESCRIPTION
According to the [YAML 1.2 specs](http://www.yaml.org/spec/1.2/spec.html) section **2.2 Structures**, the Examples 2.7 and 2.8 show that the document start `---` and end `...` can have content (such as whitespaces and comments) before and after respectively. 

The current implementation of `cleanup()` does not clean up the document start marker `---` if the marker is placed after comments. As a result, the Parser will throw an exception.

However, in this hotfix, I've changed the regular expression in the `cleanup()` process such that as long as that line contains `---` or `...` only, we remove it. 

If the markers are not used, then the usage is not affected.
