### PR TITLE
Duplicate array key

### DIFF
--- a/Tests/InlineTest.php
+++ b/Tests/InlineTest.php
@@ -194,7 +194,6 @@ class InlineTest extends \PHPUnit_Framework_TestCase
             '12.30e+02' => 12.30e+02,
             '1234' => 0x4D2,
             '1243' => 02333,
-            '.Inf' => -log(0),
             '-.Inf' => log(0),
             "'686e444'" => '686e444',
             '.Inf' => 646e444,


### PR DESCRIPTION
.Inf is being declared twice, the latter overwrites the former. (See four lines below)
