### PR TITLE
Duplicate array key

### DIFF
--- a/Tests/InlineTest.php
+++ b/Tests/InlineTest.php
@@ -197,7 +197,6 @@ class InlineTest extends \PHPUnit_Framework_TestCase
             '.Inf' => -log(0),
             '-.Inf' => log(0),
             "'686e444'" => '686e444',
-            '.Inf' => 646e444,
             '"foo\r\nbar"' => "foo\r\nbar",
             "'foo#bar'" => 'foo#bar',
             "'foo # bar'" => 'foo # bar',


### PR DESCRIPTION
.Inf is being declared twice, the latter overwrites the former. (See four lines below)

References Symfony Yaml PR#6
