### PR TITLE
added ability for substitute aliases when mapping is on single line

### DIFF
--- a/Tests/Fixtures/sfMergeKey.yml
+++ b/Tests/Fixtures/sfMergeKey.yml
@@ -20,6 +20,7 @@ yaml: |
             foo: bar
             foo: ignore
             bar: foo
+    bar_inline: {a: before, d: other, <<: *foo, b: new, x: Oren, c: { foo: bar, foo: ignore, bar: foo}}
     duplicate:
         foo: bar
         foo: ignore
@@ -33,13 +34,18 @@ yaml: |
         isit: tested
     head:
         <<: [ *foo , *dong , *foo2 ]
+    head_inline: &head_inline { <<: [ *foo , *dong , *foo2 ] }
+    recursive_inline: { <<: *head_inline, c: { <<: *foo2 } }
 php: |
     array(
         'foo' => array('a' => 'Steve', 'b' => 'Clark', 'c' => 'Brian'),
         'bar' => array('a' => 'before', 'd' => 'other', 'b' => 'new', 'c' => array('foo' => 'bar', 'bar' => 'foo'), 'x' => 'Oren'),
+        'bar_inline' => array('a' => 'before', 'd' => 'other', 'b' => 'new', 'c' => array('foo' => 'bar', 'bar' => 'foo'), 'x' => 'Oren'),
         'duplicate' => array('foo' => 'bar'),
         'foo2' => array('a' => 'Ballmer'),
         'ding' => array('fi', 'fei', 'fo', 'fam'),
         'check' => array('a' => 'Steve', 'b' => 'Clark', 'c' => 'Brian', 'fi', 'fei', 'fo', 'fam', 'isit' => 'tested'),
-        'head' => array('a' => 'Steve', 'b' => 'Clark', 'c' => 'Brian', 'fi', 'fei', 'fo', 'fam')
+        'head' => array('a' => 'Steve', 'b' => 'Clark', 'c' => 'Brian', 'fi', 'fei', 'fo', 'fam'),
+        'head_inline' => array('a' => 'Steve', 'b' => 'Clark', 'c' => 'Brian', 'fi', 'fei', 'fo', 'fam'),
+        'recursive_inline' => array('a' => 'Steve', 'b' => 'Clark', 'c' => array('a' => 'Ballmer'), 'fi', 'fei', 'fo', 'fam')
     )

--- a/Tests/ParserTest.php
+++ b/Tests/ParserTest.php
@@ -652,6 +652,18 @@ EOT
 EOF
         ));
     }
+
+    /**
+     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
+     * @expectedExceptionMessage Reference "foo" does not exist
+     */
+    public function testEvalRefException()
+    {
+        $yaml = <<<EOE
+foo: { &foo { a: Steve, <<: *foo} }
+EOE;
+        $this->parser->parse($yaml);
+    }
 }
 
 class B


### PR DESCRIPTION
At present parser only substitutes aliases when mapping is in a multiline.
When the alias is used in the mapping stored in a single line, alias substitution doesn't work.

So I modified Parser to fix it.
