### PR TITLE
RFC: Issue with nested string blocks that contain hashes.

### DIFF
--- a/Tests/Fixtures/YtsFoldedScalars.yml
+++ b/Tests/Fixtures/YtsFoldedScalars.yml
@@ -174,3 +174,31 @@ php: |
       'kept' => "This has four newlines.\n\n\n\n",
       'same as "kept" above' => "This has four newlines.\n\n\n\n"
     )
+---
+test: Include lines within blocks that start with a hash
+brief: >
+    Comments may not appear inside scalars
+yaml: |
+    shallow: |
+        a line here
+        # this should still appear
+        and another here
+php: |
+    array(
+      'shallow' => "a line here\n# this should still appear\nand another here\n"
+    )
+---
+test: Include lines within deep-nested blocks that start with a hash
+brief: >
+    Comments may not appear inside scalars
+yaml: |
+    deep:
+        nested:
+            literal: |
+                a line here
+                # this should still appear
+                and another here
+php: |
+    array(
+      'deep' => array('nested' => array('literal' => "a line here\n# this should still appear\nand another here\n"))
+    )


### PR DESCRIPTION
Adding this failing test to demonstrate the issue I'm seeing. I'm afraid a fix has me puzzled for the moment.

Lines starting with a hash, within deeply-nested string blocks, are stripped from the parsed output.

Lines starting with a hash within top-level string blocks are parsed correctly and end up in the output.

So

    my:
        nested:
            block: |
                This is a bit
                # of text
                as an example

Will parse to

    array(
        'my' => array(
            'nested' => array(
                'block' => "This is a bit\nas an example\n"
            )
        )
    )

But it should be

    array(
        'my' => array(
            'nested' => array(
                'block' => "This is a bit\n# of text\nas an example\n"
            )
        )
    )


But

    stuff:|
        Something that
        # works well


Parses to 

    array('stuff' => "Something that\n# works well");

...as far as I can tell.

Make sense?

Thanks.