### PR TITLE
[Yaml] initialize inline line numbers

### DIFF
--- a/Tests/InlineTest.php
+++ b/Tests/InlineTest.php
@@ -20,7 +20,7 @@ class InlineTest extends TestCase
 {
     protected function setUp()
     {
-        Inline::initialize(0);
+        Inline::initialize(0, 0);
     }
 
     /**


### PR DESCRIPTION
Without this change, tests from `InlineTest` cannot be executed
standalone as the parsed line number would never be initialized.