### PR TITLE
Subarray of sequential array must be inline

### DIFF
--- a/Dumper.php
+++ b/Dumper.php
@@ -81,14 +81,14 @@ class Dumper
                     $dumpObjectAsInlineMap = empty((array) $value);
                 }
 
-                $willBeInlined = $inline - 1 <= 0 || !\is_array($value) && $dumpObjectAsInlineMap || empty($value);
+                $willBeInlined = !$dumpAsMap || $inline - 1 <= 0 || !\is_array($value) && $dumpObjectAsInlineMap || empty($value);
 
                 $output .= sprintf('%s%s%s%s',
-                    $prefix,
-                    $dumpAsMap ? Inline::dump($key, $flags).':' : '-',
-                    $willBeInlined ? ' ' : "\n",
-                    $this->dump($value, $inline - 1, $willBeInlined ? 0 : $indent + $this->indentation, $flags)
-                ).($willBeInlined ? "\n" : '');
+                        $prefix,
+                        $dumpAsMap ? Inline::dump($key, $flags).':' : '-',
+                        $willBeInlined ? ' ' : "\n",
+                        $this->dump($value, $dumpAsMap ? $inline - 1 : 0, $willBeInlined ? 0 : $indent + $this->indentation, $flags)
+                    ).($willBeInlined ? "\n" : '');
             }
         }
 

--- a/Tests/Command/LintCommandTest.php
+++ b/Tests/Command/LintCommandTest.php
@@ -90,11 +90,9 @@ YAML;
         $this->assertSame(1, $ret, 'lint:yaml exits with code 1 in case of error');
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testLintFileNotReadable()
     {
+        $this->expectException(\RuntimeException::class);
         $tester = $this->createCommandTester();
         $filename = $this->createFile('');
         unlink($filename);
@@ -127,13 +125,13 @@ YAML;
         return new CommandTester($command);
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->files = [];
         @mkdir(sys_get_temp_dir().'/framework-yml-lint-test');
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         foreach ($this->files as $file) {
             if (file_exists($file)) {

--- a/Tests/InlineTest.php
+++ b/Tests/InlineTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\Yaml\Yaml;
 
 class InlineTest extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         Inline::initialize(0, 0);
     }
@@ -63,21 +63,17 @@ class InlineTest extends TestCase
         ];
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     * @expectedExceptionMessage The constant "WRONG_CONSTANT" is not defined
-     */
     public function testParsePhpConstantThrowsExceptionWhenUndefined()
     {
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('The constant "WRONG_CONSTANT" is not defined');
         Inline::parse('!php/const WRONG_CONSTANT', Yaml::PARSE_CONSTANT);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     * @expectedExceptionMessageRegExp #The string "!php/const PHP_INT_MAX" could not be parsed as a constant.*#
-     */
     public function testParsePhpConstantThrowsExceptionOnInvalidType()
     {
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessageRegExp('#The string "!php/const PHP_INT_MAX" could not be parsed as a constant.*#');
         Inline::parse('!php/const PHP_INT_MAX', Yaml::PARSE_EXCEPTION_ON_INVALID_TYPE);
     }
 
@@ -118,72 +114,56 @@ class InlineTest extends TestCase
         $this->assertSame($value, Inline::parse(Inline::dump($value)));
     }
 
-    /**
-     * @expectedException        \Symfony\Component\Yaml\Exception\ParseException
-     * @expectedExceptionMessage Found unknown escape character "\V".
-     */
     public function testParseScalarWithNonEscapedBlackslashShouldThrowException()
     {
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('Found unknown escape character "\V".');
         Inline::parse('"Foo\Var"');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     */
     public function testParseScalarWithNonEscapedBlackslashAtTheEndShouldThrowException()
     {
+        $this->expectException(ParseException::class);
         Inline::parse('"Foo\\"');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     */
     public function testParseScalarWithIncorrectlyQuotedStringShouldThrowException()
     {
+        $this->expectException(ParseException::class);
         $value = "'don't do somthin' like that'";
         Inline::parse($value);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     */
     public function testParseScalarWithIncorrectlyDoubleQuotedStringShouldThrowException()
     {
+        $this->expectException(ParseException::class);
         $value = '"don"t do somthin" like that"';
         Inline::parse($value);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     */
     public function testParseInvalidMappingKeyShouldThrowException()
     {
+        $this->expectException(ParseException::class);
         $value = '{ "foo " bar": "bar" }';
         Inline::parse($value);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     * @expectedExceptionMessage Colons must be followed by a space or an indication character (i.e. " ", ",", "[", "]", "{", "}")
-     */
     public function testParseMappingKeyWithColonNotFollowedBySpace()
     {
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('Colons must be followed by a space or an indication character (i.e. " ", ",", "[", "]", "{", "}")');
         Inline::parse('{foo:""}');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     */
     public function testParseInvalidMappingShouldThrowException()
     {
+        $this->expectException(ParseException::class);
         Inline::parse('[foo] bar');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     */
     public function testParseInvalidSequenceShouldThrowException()
     {
+        $this->expectException(ParseException::class);
         Inline::parse('{ foo: bar } bar');
     }
 
@@ -206,14 +186,14 @@ class InlineTest extends TestCase
     public function getDataForParseReferences()
     {
         return [
-            'scalar' => ['*var', 'var-value'],
-            'list' => ['[ *var ]', ['var-value']],
-            'list-in-list' => ['[[ *var ]]', [['var-value']]],
-            'map-in-list' => ['[ { key: *var } ]', [['key' => 'var-value']]],
+            'scalar'                   => ['*var', 'var-value'],
+            'list'                     => ['[ *var ]', ['var-value']],
+            'list-in-list'             => ['[[ *var ]]', [['var-value']]],
+            'map-in-list'              => ['[ { key: *var } ]', [['key' => 'var-value']]],
             'embedded-mapping-in-list' => ['[ key: *var ]', [['key' => 'var-value']]],
-            'map' => ['{ key: *var }', ['key' => 'var-value']],
-            'list-in-map' => ['{ key: [*var] }', ['key' => ['var-value']]],
-            'map-in-map' => ['{ foo: { bar: *var } }', ['foo' => ['bar' => 'var-value']]],
+            'map'                      => ['{ key: *var }', ['key' => 'var-value']],
+            'list-in-map'              => ['{ key: [*var] }', ['key' => ['var-value']]],
+            'map-in-map'               => ['{ foo: { bar: *var } }', ['foo' => ['bar' => 'var-value']]],
         ];
     }
 
@@ -227,21 +207,17 @@ class InlineTest extends TestCase
         $this->assertSame([$foo], Inline::parse('[*foo]', 0, ['foo' => $foo]));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     * @expectedExceptionMessage A reference must contain at least one character at line 1.
-     */
     public function testParseUnquotedAsterisk()
     {
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('A reference must contain at least one character at line 1.');
         Inline::parse('{ foo: * }');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     * @expectedExceptionMessage A reference must contain at least one character at line 1.
-     */
     public function testParseUnquotedAsteriskFollowedByAComment()
     {
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('A reference must contain at least one character at line 1.');
         Inline::parse('{ foo: * #foo }');
     }
 
@@ -558,9 +534,9 @@ class InlineTest extends TestCase
     {
         return [
             'canonical' => ['2001-12-15T02:59:43.1Z', 2001, 12, 15, 2, 59, 43.1, '+0000'],
-            'ISO-8601' => ['2001-12-15t21:59:43.10-05:00', 2001, 12, 16, 2, 59, 43.1, '-0500'],
-            'spaced' => ['2001-12-15 21:59:43.10 -5', 2001, 12, 16, 2, 59, 43.1, '-0500'],
-            'date' => ['2001-12-15', 2001, 12, 15, 0, 0, 0, '+0000'],
+            'ISO-8601'  => ['2001-12-15t21:59:43.10-05:00', 2001, 12, 16, 2, 59, 43.1, '-0500'],
+            'spaced'    => ['2001-12-15 21:59:43.10 -5', 2001, 12, 16, 2, 59, 43.1, '-0500'],
+            'date'      => ['2001-12-15', 2001, 12, 15, 0, 0, 0, '+0000'],
         ];
     }
 
@@ -614,16 +590,16 @@ class InlineTest extends TestCase
         return [
             'enclosed with double quotes' => ['!!binary "SGVsbG8gd29ybGQ="'],
             'enclosed with single quotes' => ["!!binary 'SGVsbG8gd29ybGQ='"],
-            'containing spaces' => ['!!binary  "SGVs bG8gd 29ybGQ="'],
+            'containing spaces'           => ['!!binary  "SGVs bG8gd 29ybGQ="'],
         ];
     }
 
     /**
      * @dataProvider getInvalidBinaryData
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
      */
     public function testParseInvalidBinaryData($data, $expectedMessage)
     {
+        $this->expectException(ParseException::class);
         if (method_exists($this, 'expectException')) {
             $this->expectExceptionMessageRegExp($expectedMessage);
         } else {
@@ -637,18 +613,16 @@ class InlineTest extends TestCase
     {
         return [
             'length not a multiple of four' => ['!!binary "SGVsbG8d29ybGQ="', '/The normalized base64 encoded data \(data without whitespace characters\) length must be a multiple of four \(\d+ bytes given\)/'],
-            'invalid characters' => ['!!binary "SGVsbG8#d29ybGQ="', '/The base64 encoded data \(.*\) contains invalid characters/'],
-            'too many equals characters' => ['!!binary "SGVsbG8gd29yb==="', '/The base64 encoded data \(.*\) contains invalid characters/'],
-            'misplaced equals character' => ['!!binary "SGVsbG8gd29ybG=Q"', '/The base64 encoded data \(.*\) contains invalid characters/'],
+            'invalid characters'            => ['!!binary "SGVsbG8#d29ybGQ="', '/The base64 encoded data \(.*\) contains invalid characters/'],
+            'too many equals characters'    => ['!!binary "SGVsbG8gd29yb==="', '/The base64 encoded data \(.*\) contains invalid characters/'],
+            'misplaced equals character'    => ['!!binary "SGVsbG8gd29ybG=Q"', '/The base64 encoded data \(.*\) contains invalid characters/'],
         ];
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     * @expectedExceptionMessage Malformed inline YAML string: {this, is not, supported} at line 1.
-     */
     public function testNotSupportedMissingValue()
     {
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('Malformed inline YAML string: {this, is not, supported} at line 1.');
         Inline::parse('{this, is not, supported}');
     }
 
@@ -662,12 +636,10 @@ class InlineTest extends TestCase
         $this->assertEquals($longStringWithQuotes, $arrayFromYaml['longStringWithQuotes']);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     * @expectedExceptionMessage Missing mapping key
-     */
     public function testMappingKeysCannotBeOmitted()
     {
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('Missing mapping key');
         Inline::parse('{: foo}');
     }
 
@@ -683,7 +655,7 @@ class InlineTest extends TestCase
     {
         return [
             'null before closing curly brace' => ['{foo:}', ['foo' => null]],
-            'null before comma' => ['{foo:, bar: baz}', ['foo' => null, 'bar' => 'baz']],
+            'null before comma'               => ['{foo:, bar: baz}', ['foo' => null, 'bar' => 'baz']],
         ];
     }
 
@@ -693,23 +665,22 @@ class InlineTest extends TestCase
     }
 
     /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     * @expectedExceptionMessage Implicit casting of incompatible mapping keys to strings is not supported. Quote your evaluable mapping keys instead
-     *
      * @dataProvider getNotPhpCompatibleMappingKeyData
      */
     public function testImplicitStringCastingOfMappingKeysIsDeprecated($yaml, $expected)
     {
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('Implicit casting of incompatible mapping keys to strings is not supported. Quote your evaluable mapping keys instead');
         $this->assertSame($expected, Inline::parse($yaml));
     }
 
     public function getNotPhpCompatibleMappingKeyData()
     {
         return [
-            'boolean-true' => ['{true: "foo"}', ['true' => 'foo']],
+            'boolean-true'  => ['{true: "foo"}', ['true' => 'foo']],
             'boolean-false' => ['{false: "foo"}', ['false' => 'foo']],
-            'null' => ['{null: "foo"}', ['null' => 'foo']],
-            'float' => ['{0.25: "foo"}', ['0.25' => 'foo']],
+            'null'          => ['{null: "foo"}', ['null' => 'foo']],
+            'float'         => ['{0.25: "foo"}', ['0.25' => 'foo']],
         ];
     }
 
@@ -749,12 +720,10 @@ class InlineTest extends TestCase
         $this->assertSame('', $value['foo']->getValue());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     * @expectedExceptionMessage Unexpected end of line, expected one of ",}" at line 1 (near "{abc: 'def'").
-     */
     public function testUnfinishedInlineMap()
     {
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('Unexpected end of line, expected one of ",}" at line 1 (near "{abc: \'def\'").');
         Inline::parse("{abc: 'def'");
     }
 }

--- a/Tests/ParserTest.php
+++ b/Tests/ParserTest.php
@@ -22,12 +22,12 @@ class ParserTest extends TestCase
     /** @var Parser */
     protected $parser;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->parser = new Parser();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->parser = null;
 
@@ -512,11 +512,9 @@ YAML;
         return $tests;
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     */
     public function testObjectsSupportDisabledWithExceptions()
     {
+        $this->expectException(ParseException::class);
         $yaml = <<<'EOF'
 foo: !php/object:O:30:"Symfony\Tests\Component\Yaml\B":1:{s:1:"b";s:3:"foo";}
 bar: 1
@@ -526,7 +524,7 @@ EOF;
     }
 
     /**
-     * @group legacy
+     * @group               legacy
      * @expectedDeprecation Support for mapping keys in multi-line blocks is deprecated since Symfony 4.3 and will throw a ParseException in 5.0.
      */
     public function testMappingKeyInMultiLineStringTriggersDeprecationNotice()
@@ -572,11 +570,9 @@ EOF;
         }
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     */
     public function testUnindentedCollectionException()
     {
+        $this->expectException(ParseException::class);
         $yaml = <<<'EOF'
 
 collection:
@@ -589,11 +585,9 @@ EOF;
         $this->parser->parse($yaml);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     */
     public function testShortcutKeyUnindentedCollectionException()
     {
+        $this->expectException(ParseException::class);
         $yaml = <<<'EOF'
 
 collection:
@@ -605,12 +599,10 @@ EOF;
         $this->parser->parse($yaml);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     * @expectedExceptionMessageRegExp /^Multiple documents are not supported.+/
-     */
     public function testMultipleDocumentsNotSupportedException()
     {
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessageRegExp('/^Multiple documents are not supported.+/');
         Yaml::parse(<<<'EOL'
 # Ranking of 1998 home runs
 ---
@@ -626,11 +618,9 @@ EOL
         );
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     */
     public function testSequenceInAMapping()
     {
+        $this->expectException(ParseException::class);
         Yaml::parse(<<<'EOF'
 yaml:
   hash: me
@@ -735,10 +725,10 @@ EOT;
 
     /**
      * @dataProvider getParseExceptionNotAffectedMultiLineStringLastResortParsing
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
      */
     public function testParseExceptionNotAffectedByMultiLineStringLastResortParsing($yaml)
     {
+        $this->expectException(ParseException::class);
         $this->parser->parse($yaml);
     }
 
@@ -768,11 +758,9 @@ EOT;
         $this->assertSame($expected, $this->parser->parse($yaml));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     */
     public function testMappingInASequence()
     {
+        $this->expectException(ParseException::class);
         Yaml::parse(<<<'EOF'
 yaml:
   - array stuff
@@ -781,12 +769,10 @@ EOF
         );
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     * @expectedExceptionMessage missing colon
-     */
     public function testScalarInSequence()
     {
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('missing colon');
         Yaml::parse(<<<'EOF'
 foo:
     - bar
@@ -797,9 +783,6 @@ EOF
     }
 
     /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     * @expectedExceptionMessage Duplicate key "child" detected
-     *
      * > It is an error for two equal keys to appear in the same mapping node.
      * > In such a case the YAML processor may continue, ignoring the second
      * > "key: value" pair and issuing an appropriate warning. This strategy
@@ -811,6 +794,8 @@ EOF
      */
     public function testMappingDuplicateKeyBlock()
     {
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('Duplicate key "child" detected');
         $input = <<<'EOD'
 parent:
     child: first
@@ -827,12 +812,10 @@ EOD;
         $this->assertSame($expected, Yaml::parse($input));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     * @expectedExceptionMessage Duplicate key "child" detected
-     */
     public function testMappingDuplicateKeyFlow()
     {
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('Duplicate key "child" detected');
         $input = <<<'EOD'
 parent: { child: first, child: duplicate }
 parent: { child: duplicate, child: duplicate }
@@ -846,11 +829,11 @@ EOD;
     }
 
     /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
      * @dataProvider getParseExceptionOnDuplicateData
      */
     public function testParseExceptionOnDuplicate($input, $duplicateKey, $lineNumber)
     {
+        $this->expectException(ParseException::class);
         $this->expectExceptionMessage(sprintf('Duplicate key "%s" detected at line %d', $duplicateKey, $lineNumber));
 
         Yaml::parse($input);
@@ -989,7 +972,7 @@ header
 
 footer # comment3
 EOT
-        ]], Yaml::parse(<<<'EOF'
+                             ]], Yaml::parse(<<<'EOF'
 -
     content: |
         # comment 1
@@ -1008,8 +991,8 @@ EOF
     public function testNestedFoldedStringBlockWithComments()
     {
         $this->assertEquals([[
-            'title' => 'some title',
-            'content' => <<<'EOT'
+                                 'title'   => 'some title',
+                                 'content' => <<<'EOT'
 # comment 1
 header
 
@@ -1020,7 +1003,7 @@ header
 
 footer # comment3
 EOT
-        ]], Yaml::parse(<<<'EOF'
+                             ]], Yaml::parse(<<<'EOF'
 -
     title: some title
     content: |
@@ -1040,15 +1023,15 @@ EOF
     public function testReferenceResolvingInInlineStrings()
     {
         $this->assertEquals([
-            'var' => 'var-value',
-            'scalar' => 'var-value',
-            'list' => ['var-value'],
-            'list_in_list' => [['var-value']],
-            'map_in_list' => [['key' => 'var-value']],
+            'var'              => 'var-value',
+            'scalar'           => 'var-value',
+            'list'             => ['var-value'],
+            'list_in_list'     => [['var-value']],
+            'map_in_list'      => [['key' => 'var-value']],
             'embedded_mapping' => [['key' => 'var-value']],
-            'map' => ['key' => 'var-value'],
-            'list_in_map' => ['key' => ['var-value']],
-            'map_in_map' => ['foo' => ['bar' => 'var-value']],
+            'map'              => ['key' => 'var-value'],
+            'list_in_map'      => ['key' => ['var-value']],
+            'map_in_map'       => ['foo' => ['bar' => 'var-value']],
         ], Yaml::parse(<<<'EOF'
 var:  &var var-value
 scalar: *var
@@ -1074,12 +1057,10 @@ EOF;
         $this->assertEquals(['foo' => 1, 'bar' => 2], $this->parser->parse($yaml));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     * @expectedExceptionMessage Numeric keys are not supported. Quote your evaluable mapping keys instead
-     */
     public function testFloatKeys()
     {
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('Numeric keys are not supported. Quote your evaluable mapping keys instead');
         $yaml = <<<'EOF'
 foo:
     1.2: "bar"
@@ -1089,12 +1070,10 @@ EOF;
         $this->parser->parse($yaml);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     * @expectedExceptionMessage Non-string keys are not supported. Quote your evaluable mapping keys instead
-     */
     public function testBooleanKeys()
     {
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('Non-string keys are not supported. Quote your evaluable mapping keys instead');
         $yaml = <<<'EOF'
 true: foo
 false: bar
@@ -1117,23 +1096,21 @@ EOF;
 EOF;
 
         $expected = [
-            '1.2' => 'bar',
-            '1.3' => 'baz',
-            'true' => 'foo',
+            '1.2'   => 'bar',
+            '1.3'   => 'baz',
+            'true'  => 'foo',
             'false' => 'bar',
-            'null' => 'null',
-            '~' => 'null',
+            'null'  => 'null',
+            '~'     => 'null',
         ];
 
         $this->assertEquals($expected, $this->parser->parse($yaml));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     * @expectedExceptionMessage A colon cannot be used in an unquoted mapping value
-     */
     public function testColonInMappingValueException()
     {
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('A colon cannot be used in an unquoted mapping value');
         $yaml = <<<'EOF'
 foo: bar: baz
 EOF;
@@ -1181,7 +1158,7 @@ EOT;
         $expected = [
             'pages' => [
                 [
-                    'title' => 'some title',
+                    'title'   => 'some title',
                     'content' => <<<'EOT'
 # comment 1
 header
@@ -1215,7 +1192,7 @@ collection:
         baz
 EOT;
         $expected = [
-            'test' => <<<'EOT'
+            'test'       => <<<'EOT'
 foo
 # bar
 baz
@@ -1347,30 +1324,30 @@ EOT
     public function getBinaryData()
     {
         return [
-            'enclosed with double quotes' => ['data: !!binary "SGVsbG8gd29ybGQ="'],
-            'enclosed with single quotes' => ["data: !!binary 'SGVsbG8gd29ybGQ='"],
-            'containing spaces' => ['data: !!binary  "SGVs bG8gd 29ybGQ="'],
-            'in block scalar' => [
+            'enclosed with double quotes'       => ['data: !!binary "SGVsbG8gd29ybGQ = "'],
+            'enclosed with single quotes'       => ["data: !!binary 'SGVsbG8gd29ybGQ='"],
+            'containing spaces'                 => ['data: !!binary  "SGVs bG8gd 29ybGQ = "'],
+            'in block scalar'                   => [
                 <<<'EOT'
 data: !!binary |
     SGVsbG8gd29ybGQ=
 EOT
-    ],
+            ],
             'containing spaces in block scalar' => [
                 <<<'EOT'
 data: !!binary |
     SGVs bG8gd 29ybGQ=
 EOT
-    ],
+            ],
         ];
     }
 
     /**
      * @dataProvider getInvalidBinaryData
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
      */
     public function testParseInvalidBinaryData($data, $expectedMessage)
     {
+        $this->expectException(ParseException::class);
         if (method_exists($this, 'expectException')) {
             $this->expectExceptionMessageRegExp($expectedMessage);
         } else {
@@ -1383,10 +1360,10 @@ EOT
     public function getInvalidBinaryData()
     {
         return [
-            'length not a multiple of four' => ['data: !!binary "SGVsbG8d29ybGQ="', '/The normalized base64 encoded data \(data without whitespace characters\) length must be a multiple of four \(\d+ bytes given\)/'],
-            'invalid characters' => ['!!binary "SGVsbG8#d29ybGQ="', '/The base64 encoded data \(.*\) contains invalid characters/'],
-            'too many equals characters' => ['data: !!binary "SGVsbG8gd29yb==="', '/The base64 encoded data \(.*\) contains invalid characters/'],
-            'misplaced equals character' => ['data: !!binary "SGVsbG8gd29ybG=Q"', '/The base64 encoded data \(.*\) contains invalid characters/'],
+            'length not a multiple of four'                 => ['data: !!binary "SGVsbG8d29ybGQ = "', '/The normalized base64 encoded data \(data without whitespace characters\) length must be a multiple of four \(\d+ bytes given\)/'],
+            'invalid characters'                            => ['!!binary "SGVsbG8#d29ybGQ="', '/The base64 encoded data \(.*\) contains invalid characters/'],
+            'too many equals characters'                    => ['data: !!binary "SGVsbG8gd29yb==="', '/The base64 encoded data \(.*\) contains invalid characters/'],
+            'misplaced equals character'                    => ['data: !!binary "SGVsbG8gd29ybG=Q"', '/The base64 encoded data \(.*\) contains invalid characters/'],
             'length not a multiple of four in block scalar' => [
                 <<<'EOT'
 data: !!binary |
@@ -1395,7 +1372,7 @@ EOT
                 ,
                 '/The normalized base64 encoded data \(data without whitespace characters\) length must be a multiple of four \(\d+ bytes given\)/',
             ],
-            'invalid characters in block scalar' => [
+            'invalid characters in block scalar'            => [
                 <<<'EOT'
 data: !!binary |
     SGVsbG8#d29ybGQ=
@@ -1403,7 +1380,7 @@ EOT
                 ,
                 '/The base64 encoded data \(.*\) contains invalid characters/',
             ],
-            'too many equals characters in block scalar' => [
+            'too many equals characters in block scalar'    => [
                 <<<'EOT'
 data: !!binary |
     SGVsbG8gd29yb===
@@ -1411,7 +1388,7 @@ EOT
                 ,
                 '/The base64 encoded data \(.*\) contains invalid characters/',
             ],
-            'misplaced equals character in block scalar' => [
+            'misplaced equals character in block scalar'    => [
                 <<<'EOT'
 data: !!binary |
     SGVsbG8gd29ybG=Q
@@ -1540,7 +1517,7 @@ YAML;
         $expected = [
             'foo' => [
                 'foobar' => 'foo #bar',
-                'bar' => 'baz',
+                'bar'    => 'baz',
             ],
         ];
 
@@ -1662,7 +1639,7 @@ EOF;
     public function taggedValuesProvider()
     {
         return [
-            'scalars' => [
+            'scalars'                             => [
                 [
                     'foo' => new TaggedValue('inline', 'bar'),
                     'quz' => new TaggedValue('long', 'this is a long text'),
@@ -1674,7 +1651,7 @@ quz: !long >
   text
 YAML
             ],
-            'sequences' => [
+            'sequences'                           => [
                 [new TaggedValue('foo', ['yaml']), new TaggedValue('quz', ['bar'])],
                 <<<YAML
 - !foo
@@ -1682,7 +1659,7 @@ YAML
 - !quz [bar]
 YAML
             ],
-            'mappings' => [
+            'mappings'                            => [
                 new TaggedValue('foo', ['foo' => new TaggedValue('quz', ['bar']), 'quz' => new TaggedValue('foo', ['quz' => 'bar'])]),
                 <<<YAML
 !foo
@@ -1691,7 +1668,7 @@ quz: !foo
    quz: bar
 YAML
             ],
-            'inline' => [
+            'inline'                              => [
                 [new TaggedValue('foo', ['foo', 'bar']), new TaggedValue('quz', ['foo' => 'bar', 'quz' => new TaggedValue('bar', ['one' => 'bar'])])],
                 <<<YAML
 - !foo [foo, bar]
@@ -1710,48 +1687,38 @@ YAML
         $this->assertSame('12', $this->parser->parse('! 12'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     * @expectedExceptionMessage Tags support is not enabled. Enable the "Yaml::PARSE_CUSTOM_TAGS" flag to use "!iterator" at line 1 (near "!iterator [foo]").
-     */
     public function testCustomTagsDisabled()
     {
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('Tags support is not enabled. Enable the "Yaml::PARSE_CUSTOM_TAGS" flag to use "!iterator" at line 1 (near "!iterator [foo]").');
         $this->parser->parse('!iterator [foo]');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     * @expectedExceptionMessage Tags support is not enabled. Enable the "Yaml::PARSE_CUSTOM_TAGS" flag to use "!iterator" at line 1 (near "!iterator foo").
-     */
     public function testUnsupportedTagWithScalar()
     {
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('Tags support is not enabled. Enable the "Yaml::PARSE_CUSTOM_TAGS" flag to use "!iterator" at line 1 (near "!iterator foo").');
         $this->parser->parse('!iterator foo');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     * @expectedExceptionMessage The string "!!iterator foo" could not be parsed as it uses an unsupported built-in tag at line 1 (near "!!iterator foo").
-     */
     public function testUnsupportedBuiltInTagWithScalar()
     {
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('The string "!!iterator foo" could not be parsed as it uses an unsupported built-in tag at line 1 (near "!!iterator foo").');
         $this->parser->parse('!!iterator foo');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     * @expectedExceptionMessage The built-in tag "!!foo" is not implemented at line 1 (near "!!foo").
-     */
     public function testExceptionWhenUsingUnsuportedBuiltInTags()
     {
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('The built-in tag "!!foo" is not implemented at line 1 (near "!!foo").');
         $this->parser->parse('!!foo');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     * @expectedExceptionMessage Complex mappings are not supported at line 1 (near "? "1"").
-     */
     public function testComplexMappingThrowsParseException()
     {
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('Complex mappings are not supported at line 1 (near "? "1"").');
         $yaml = <<<YAML
 ? "1"
 :
@@ -1761,12 +1728,10 @@ YAML;
         $this->parser->parse($yaml);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     * @expectedExceptionMessage Complex mappings are not supported at line 2 (near "? "1"").
-     */
     public function testComplexMappingNestedInMappingThrowsParseException()
     {
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('Complex mappings are not supported at line 2 (near "? "1"").');
         $yaml = <<<YAML
 diet:
   ? "1"
@@ -1777,12 +1742,10 @@ YAML;
         $this->parser->parse($yaml);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     * @expectedExceptionMessage Complex mappings are not supported at line 1 (near "- ? "1"").
-     */
     public function testComplexMappingNestedInSequenceThrowsParseException()
     {
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('Complex mappings are not supported at line 1 (near "- ? "1"").');
         $yaml = <<<YAML
 - ? "1"
   :
@@ -1792,12 +1755,10 @@ YAML;
         $this->parser->parse($yaml);
     }
 
-    /**
-     * @expectedException        \Symfony\Component\Yaml\Exception\ParseException
-     * @expectedExceptionMessage Unable to parse at line 1 (near "[parameters]").
-     */
     public function testParsingIniThrowsException()
     {
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('Unable to parse at line 1 (near "[parameters]").');
         $ini = <<<INI
 [parameters]
   foo = bar
@@ -1847,12 +1808,10 @@ INI;
         $this->assertEquals($trickyVal, $arrayFromYaml);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     * @expectedExceptionMessage Reference "foo" does not exist at line 2
-     */
     public function testParserCleansUpReferencesBetweenRuns()
     {
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('Reference "foo" does not exist at line 2');
         $yaml = <<<YAML
 foo: &foo
     baz: foobar
@@ -1883,7 +1842,7 @@ YAML;
                     'from' => [
                         'bar',
                     ],
-                    'to' => 'baz',
+                    'to'   => 'baz',
                 ],
             ],
         ];
@@ -1908,14 +1867,14 @@ foobar:
     <<: [*FOO, *BAR]
 YAML;
         $expected = (object) [
-            'foo' => (object) [
+            'foo'    => (object) [
                 'bar' => 1,
             ],
-            'bar' => (object) [
+            'bar'    => (object) [
                 'baz' => 2,
                 'bar' => 1,
             ],
-            'baz' => (object) [
+            'baz'    => (object) [
                 'baz_foo' => 3,
                 'baz_bar' => 4,
             ],
@@ -1940,21 +1899,17 @@ YAML;
         $this->assertInternalType('array', $this->parser->parseFile(__DIR__.'/Fixtures/index.yml'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     * @expectedExceptionMessageRegExp #^File ".+/Fixtures/nonexistent.yml" does not exist\.$#
-     */
     public function testParsingNonExistentFilesThrowsException()
     {
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessageRegExp('#^File ".+/Fixtures/nonexistent.yml" does not exist\.$#');
         $this->parser->parseFile(__DIR__.'/Fixtures/nonexistent.yml');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     * @expectedExceptionMessageRegExp #^File ".+/Fixtures/not_readable.yml" cannot be read\.$#
-     */
     public function testParsingNotReadableFilesThrowsException()
     {
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessageRegExp('#^File ".+/Fixtures/not_readable.yml" cannot be read\.$#');
         if ('\\' === \DIRECTORY_SEPARATOR) {
             $this->markTestSkipped('chmod is not supported on Windows');
         }
@@ -1987,7 +1942,7 @@ YAML;
                 'b' => 'bar',
                 'c' => 'baz',
             ],
-            'mergekeyderef' => [
+            'mergekeyderef'  => [
                 'd' => 'quux',
                 'b' => 'bar',
                 'c' => 'baz',
@@ -2015,7 +1970,7 @@ YAML;
                 'b' => 'bar',
                 'c' => 'baz',
             ],
-            'mergekeyderef' => (object) [
+            'mergekeyderef'  => (object) [
                 'd' => 'quux',
                 'b' => 'bar',
                 'c' => 'baz',
@@ -2025,12 +1980,10 @@ YAML;
         $this->assertEquals($expected, $this->parser->parse($yaml, Yaml::PARSE_OBJECT_FOR_MAP));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     * @expectedExceptionMessage Reference "foo" does not exist
-     */
     public function testEvalRefException()
     {
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('Reference "foo" does not exist');
         $yaml = <<<EOE
 foo: { &foo { a: Steve, <<: *foo} }
 EOE;
@@ -2039,11 +1992,11 @@ EOE;
 
     /**
      * @dataProvider circularReferenceProvider
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     * @expectedExceptionMessage Circular reference [foo, bar, foo] detected
      */
     public function testDetectCircularReferences($yaml)
     {
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('Circular reference [foo, bar, foo] detected');
         $this->parser->parse($yaml, Yaml::PARSE_CUSTOM_TAGS);
     }
 

--- a/Tests/YamlTest.php
+++ b/Tests/YamlTest.php
@@ -24,21 +24,17 @@ class YamlTest extends TestCase
         $this->assertEquals($data, $parsed);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The indentation must be greater than zero
-     */
     public function testZeroIndentationThrowsException()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The indentation must be greater than zero');
         Yaml::dump(['lorem' => 'ipsum', 'dolor' => 'sit'], 2, 0);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The indentation must be greater than zero
-     */
     public function testNegativeIndentationThrowsException()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The indentation must be greater than zero');
         Yaml::dump(['lorem' => 'ipsum', 'dolor' => 'sit'], 2, -4);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "symfony/polyfill-ctype": "~1.8"
     },
     "require-dev": {
-        "symfony/console": "^4.4|^5.0"
+        "symfony/console": "^4.4|^5.0",
+        "symfony/phpunit-bridge": "^4.2"
     },
     "suggest": {
         "symfony/console": "For validating YAML files using the lint command"


### PR DESCRIPTION
Hello,

As I investigated [this issue](https://github.com/symfony/maker-bundle/issues/396), I noticed this rule which seems to me implicit. Here is the most surgical changes to obtain the expected result without break the existing output.

I have adding phpunit into project and update tests to remove coming deprecations of phpunit, because this is not bundled, and I have started the tests with my local phpunit (8).