### PR TITLE
Making the parser stateless.

### DIFF
--- a/Parser.php
+++ b/Parser.php
@@ -99,6 +99,7 @@ class Parser
             if (null !== $mbEncoding) {
                 mb_internal_encoding($mbEncoding);
             }
+            $this->offset = 0;
             $this->lines = [];
             $this->currentLine = '';
             $this->numberOfParsedLines = 0;


### PR DESCRIPTION
Currently if you parse multiple files with the same `Parser` instance, you get different results in the error reporting since the parser doesn't reset the offset.

## How to reproduce
```php
<?php
include "vendor/autoload.php";

use Symfony\Component\Yaml\Parser;


$yamlString = "# translations/messages.en.yaml

sylius:
    form:
        catalog_promotion:
            action:
                fixed_price: 'Fixed price'
";

$yaml = new Parser();
$yaml->parse($yamlString);
$yaml->parse($yamlString);
try {
$yaml->parse("abc:
	abc");
} catch (\Exception $e) {
	echo $e->getMessage();
	// Returns: A YAML file cannot contain tabs as indentation at line 4 (near "	abc")
	// This is incorrect because the error is on line 2.
	// Adding more calls to $yaml->parse($yamlString) will mess with the error reporting even more
}
```